### PR TITLE
Use Config.Filter to skip middleware

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -93,6 +93,10 @@ func New(handler func(*Conn), config ...Config) fiber.Handler {
         },
     }
     return func(c *fiber.Ctx) error {
+        if cfg.Filter != nil && !cfg.Filter(c) {
+            return c.Next()
+        }
+
         conn := acquireConn()
         // locals
         c.Context().VisitUserValues(func(key []byte, value interface{}) {


### PR DESCRIPTION
It seems like `Config.Filter` remained unused. One can now skip the websocket middleware if so desired. Returning `false` in the function means the middleware will be skipped and `c.Next()` will be called instead.

```go
app.Use(websocket.New(func(c *websocket.Conn) {
	// Etc...
}, websocket.Config{
	Filter: func(c *fiber.Ctx) bool {
		return websocket.IsWebSocketUpgrade(c)
	},
}))
```